### PR TITLE
Change Document categories/types webscripts to output using UTF-8 cha…

### DIFF
--- a/openesdh-repo/pom.xml
+++ b/openesdh-repo/pom.xml
@@ -352,6 +352,8 @@
                                 </goals>
                                 <phase>integration-test</phase>
                                 <configuration>
+                                    <!-- The default is ISO-8859-1 -->
+                                    <uriEncoding>utf-8</uriEncoding>
                                     <useTestClasspath>false</useTestClasspath>
                                     <ignorePackaging>true</ignorePackaging>
                                     <useSeparateTomcatClassLoader>true</useSeparateTomcatClassLoader>

--- a/openesdh-repo/src/main/java/dk/openesdh/repo/webscripts/documents/DocumentCategoriesWebScript.java
+++ b/openesdh-repo/src/main/java/dk/openesdh/repo/webscripts/documents/DocumentCategoriesWebScript.java
@@ -8,6 +8,8 @@ import static dk.openesdh.repo.webscripts.ParamUtils.checkRequiredParam;
 import java.io.IOException;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import dk.openesdh.repo.webscripts.utils.WebScriptUtils;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.codehaus.plexus.util.StringUtils;
 import org.json.JSONArray;
@@ -36,6 +38,7 @@ public class DocumentCategoriesWebScript extends AbstractRESTWebscript {
 
     @Override
     protected void get(NodeRef nodeRef, WebScriptRequest req, WebScriptResponse res) throws IOException, JSONException {
+        res.setContentEncoding(WebScriptUtils.CONTENT_ENCODING_UTF_8);
         if (nodeRef == null) {
             new JSONArray(documentCategoryService.getDocumentCategories().stream()
                     .map(DocumentCategory::toJSONObject)
@@ -55,6 +58,7 @@ public class DocumentCategoriesWebScript extends AbstractRESTWebscript {
         String name = ParamUtils.getRequiredParameter(req, "name");
         String displayName = ParamUtils.getRequiredParameter(req, "displayName");
         DocumentCategory savedDocumentCategory = createOrUpdateDocumentCategory(nodeRef, name, displayName);
+        res.setContentEncoding(WebScriptUtils.CONTENT_ENCODING_UTF_8);
         writeDocumentCategoryToResponse(savedDocumentCategory, res);
     }
 

--- a/openesdh-repo/src/main/java/dk/openesdh/repo/webscripts/documents/DocumentTypesWebScript.java
+++ b/openesdh-repo/src/main/java/dk/openesdh/repo/webscripts/documents/DocumentTypesWebScript.java
@@ -8,6 +8,8 @@ import static dk.openesdh.repo.webscripts.ParamUtils.checkRequiredParam;
 import java.io.IOException;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import dk.openesdh.repo.webscripts.utils.WebScriptUtils;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.codehaus.plexus.util.StringUtils;
 import org.json.JSONArray;
@@ -36,6 +38,7 @@ public class DocumentTypesWebScript extends AbstractRESTWebscript {
 
     @Override
     protected void get(NodeRef nodeRef, WebScriptRequest req, WebScriptResponse res) throws IOException, JSONException {
+        res.setContentEncoding(WebScriptUtils.CONTENT_ENCODING_UTF_8);
         if (nodeRef == null) {
             new JSONArray(documentTypeService.getDocumentTypes().stream()
                     .map(DocumentType::toJSONObject)
@@ -55,6 +58,7 @@ public class DocumentTypesWebScript extends AbstractRESTWebscript {
         String name = ParamUtils.getRequiredParameter(req, "name");
         String displayName = ParamUtils.getRequiredParameter(req, "displayName");
         DocumentType saveDocumentType = createOrUpdateDocumentType(nodeRef, name, displayName);
+        res.setContentEncoding(WebScriptUtils.CONTENT_ENCODING_UTF_8);
         writeDocumentTypeToResponse(saveDocumentType, res);
     }
 


### PR DESCRIPTION
…racter encoding.

Change the embedded Tomcat used for testing to use the UTF-8 URIEncoding by default (this matches production).
- When running integration-test, issues with query-string parameters containing Danish characters should be fixed
