### PR TITLE
updating bootstrap context

### DIFF
--- a/openesdh-simple-case/src/main/amp/config/alfresco/module/openesdh-simple-case/context/bootstrap-context.xml
+++ b/openesdh-simple-case/src/main/amp/config/alfresco/module/openesdh-simple-case/context/bootstrap-context.xml
@@ -36,6 +36,7 @@
     
     <bean id="${project.artifactId}_bootstrapGroups" class="org.alfresco.repo.module.ImporterModuleComponent" parent="module.baseComponent">
       <property name="moduleId" value="${project.artifactId}" />
+      <property name="executeOnceOnly" value="true" />
       <property name="name" value="${project.artifactId}_bootstrapGroups" />
       <property name="description" value="Import Simple Case groups" />
       <property name="sinceVersion" value="${noSnapshotVersion}" />        


### PR DESCRIPTION
When attempting to reinstall this module in an already deployed openesdh this error:
`Caused by: org.alfresco.error.AlfrescoRuntimeException: 06210005 The module component has already been executed: openesdh-simple-case.openesdh-simple-case_bootstrapGroups`
is thrown. Testing if the executeOnlyOnce property can remedy the situation
